### PR TITLE
Implementing allocators for use in the project's data structures

### DIFF
--- a/src/helpers/allocator.ts
+++ b/src/helpers/allocator.ts
@@ -1,0 +1,86 @@
+export interface IAllocator {
+  allocate(element: unknown): number;
+  retrieve(pointer: number): unknown;
+  deallocate(element: unknown): void;
+  deallocateRetrievePointer(pointer: number): unknown;
+}
+
+export class UniqueAllocator implements IAllocator {
+  private objectPointers: Map<unknown, number>;
+  private pointerMemory: unknown[];
+  private freePointers: Set<number>;
+  private pointer = 0;
+  constructor() {
+    this.objectPointers = new Map<unknown, number>();
+    this.pointerMemory = [];
+    this.freePointers = new Set<number>();
+  }
+
+  allocate(element: unknown): number {
+    if (this.objectPointers.has(element)) {
+      const pointer = this.objectPointers.get(element)!;
+      this.freePointers.delete(pointer);
+      return pointer;
+    }
+    this.objectPointers.set(element, this.pointer);
+    this.pointerMemory[this.pointer] = element;
+
+    return this.pointer++;
+  }
+
+  retrieve(pointer: number): unknown | undefined {
+    return this.pointerMemory[pointer];
+  }
+
+  deallocate(element: unknown): void {
+    const pointer = this.objectPointers.get(element);
+    if (pointer !== undefined) {
+      this.objectPointers.delete(element);
+      this.freePointers.add(pointer);
+    }
+  }
+
+  deallocateRetrievePointer(pointer: number): unknown | undefined {
+    const element = this.retrieve(pointer);
+    this.objectPointers.delete(element);
+    this.freePointers.add(pointer);
+    return element;
+  }
+}
+
+export class RepeatAllocator implements IAllocator {
+  private pointerSpace: unknown[];
+  private freePointers: number[];
+  private pointer = 0;
+  constructor() {
+    this.pointerSpace = [];
+    this.freePointers = [];
+  }
+
+  allocate(element: unknown): number {
+    this.pointerSpace[this.pointer] = element;
+    return this.pointer++;
+  }
+
+  deallocate(element: unknown): void {
+    for (
+      let pointer = this.pointerSpace.indexOf(element);
+      pointer !== -1;
+      pointer = this.pointerSpace.indexOf(element, pointer)
+    ) {
+      this.pointerSpace[pointer] = null;
+      this.freePointers.push(pointer);
+    }
+  }
+
+  deallocateRetrievePointer(pointer: number): unknown {
+    const element = this.retrieve(pointer);
+    this.pointerSpace[pointer] = null;
+    this.freePointers.push(pointer);
+    return element;
+  }
+
+  retrieve(pointer: number): unknown {
+    return this.pointerSpace[pointer];
+  }
+}

--- a/src/structures/heap/CHeap.ts
+++ b/src/structures/heap/CHeap.ts
@@ -1,14 +1,15 @@
 import IHeap, { IComparable } from './IHeap';
 import { Heap } from '../assembly/output';
+import { IAllocator, RepeatAllocator } from '../../helpers/allocator';
 
 export default class CHeap<T extends IComparable> implements IHeap<T> {
   private readonly isMax: boolean;
   private readonly heap: Heap;
-  private pointer = 0;
-  private ptrArray: T[] = [];
+  private readonly allocator: IAllocator;
   constructor(list: T[] = [], isMax = true) {
-    this.heap = new Heap();
     this.isMax = isMax;
+    this.heap = new Heap();
+    this.allocator = new RepeatAllocator();
 
     for (const element of list) {
       this.insert(element);
@@ -20,7 +21,7 @@ export default class CHeap<T extends IComparable> implements IHeap<T> {
     if (pointer === -1) {
       return;
     }
-    return this.ptrArray[pointer];
+    return <T>this.allocator.deallocateRetrievePointer(pointer);
   }
 
   size(): number {
@@ -28,8 +29,9 @@ export default class CHeap<T extends IComparable> implements IHeap<T> {
   }
 
   insert(element: T) {
-    this.ptrArray[this.pointer] = element;
-    this.heap.insert(this.pointer, element.valueOf() * (this.isMax ? 1 : -1));
-    this.pointer++;
+    this.heap.insert(
+      this.allocator.allocate(element),
+      element.valueOf() * (this.isMax ? 1 : -1)
+    );
   }
 }

--- a/src/structures/heap/CHeap.ts
+++ b/src/structures/heap/CHeap.ts
@@ -1,11 +1,11 @@
 import IHeap, { IComparable } from './IHeap';
 import { Heap } from '../assembly/output';
-import { IAllocator, RepeatAllocator } from '../../helpers/allocator';
+import { RepeatAllocator } from '../../helpers/allocator';
 
 export default class CHeap<T extends IComparable> implements IHeap<T> {
   private readonly isMax: boolean;
   private readonly heap: Heap;
-  private readonly allocator: IAllocator;
+  private readonly allocator: RepeatAllocator;
   constructor(list: T[] = [], isMax = true) {
     this.isMax = isMax;
     this.heap = new Heap();


### PR DESCRIPTION
Closes #5 

Creating two allocators, one that allows for repetition and has a smaller ovehead and another that doesn't. 

These allocators, as efficient as they are, added a non negligible overhead to several of the data structure's operations. It would be very useful to figure out a better solution to this. This is described in #6.